### PR TITLE
change state to finishing on cached loggins

### DIFF
--- a/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -510,6 +510,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection {
 			if ( cached != null && cached.getName().equals( getName() ) )
 			{
 				BungeeCord.getInstance().getLogger().log( Level.FINE, () -> "Logged in cached " + cached + " from " + getSocketAddress() );
+				thisState = State.FINISHING;
 				loginProfile = cached;
 				name = cached.getName();
 				uniqueId = Util.getUUID( cached.getId() );


### PR DESCRIPTION
due to the LoginEvent wich is async we need to change the state here to otherwise you could send a second encription response packet cause the state is not changed before the async event calls the callback

This issue is not a big deal but we should notice it